### PR TITLE
fix: Ensure tool specific scripts are defered until jquery is loaded

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -60,13 +60,13 @@
   
 {% if page.include_remote_javascript %}
   {% for src in page.include_remote_javascript %}
-    <script src="{{src}}"></script>
+    <script defer src="{{src}}"></script>
   {% endfor %}
 {% endif %}
 
 {% if page.include_javascript %}
   {% for filename in page.include_javascript %}
-    <script src="/javascripts/{{filename}}.js"></script>
+    <script defer src="/javascripts/{{filename}}.js"></script>
   {% endfor %}
 {% endif %}
 


### PR DESCRIPTION
The satoshi calc and the hashrate calc use jQuery, but were run before jQuery was fully loaded. So they used something that wasn't available yet.

By deferring the loading, we ensure that our tools scripts are only ran and evaluated after all other resources are loaded. This is slightly slower, as it waits for all resources, including possible analytics or fonts are loaded before the tool is ran. 
On the other hand, it's safer to be sure that all stuff, including fonts, CSS and whatnot is fully loaded before running the scripts that manipulate that.

![image](https://github.com/JTuwiner/BitcoinTools/assets/77059/854534a2-f33f-4280-a827-13179ad0b360)
